### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ exports.normalize = normalize;
 function slashGlob (value) {
     
   if (value.charAt(0) === '!') {
-    return '!' + exports.normalize(value.substr(1));
+    return '!' + exports.normalize(value.slice(1));
   }
   
   return exports.normalize(value);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.